### PR TITLE
fix: canceled forms not showing rejection reason

### DIFF
--- a/app/docs/dashboard/page.tsx
+++ b/app/docs/dashboard/page.tsx
@@ -33,12 +33,11 @@ export default function DocsDashboardPage() {
           (signingParty) =>
             signingParty.signatory_account?.email === profile.email && !signingParty.signed
         );
-        const rejectionReason = form.rejection_reason;
 
         return (
           lastUnsignedSigningParty?._id === mySigningParty?._id &&
           !form.signed_document_id &&
-          !rejectionReason
+          !form.rejection_reason
         );
       },
     },
@@ -55,7 +54,7 @@ export default function DocsDashboardPage() {
       },
     },
     {
-      id: "rejected",
+      id: "cancelled",
       label: "Cancelled",
       icon: () => (
         <div className="bg-destructive rounded-full p-1 text-white">
@@ -79,7 +78,7 @@ export default function DocsDashboardPage() {
             signingParty.signatory_account?.email === profile.email && !signingParty.signed
         );
 
-        return lastUnsignedSigningParty?._id !== mySigningParty?._id;
+        return lastUnsignedSigningParty?._id !== mySigningParty?._id && !form.rejection_reason;
       },
     },
   ];

--- a/components/docs/dashboard/FormTable.tsx
+++ b/components/docs/dashboard/FormTable.tsx
@@ -143,13 +143,6 @@ const createActionColumns = (
             <Download className="h-4 w-4" />
           </Button>
         );
-      } else if (lastUnsignedSigningParty?._id !== mySigningParty?._id) {
-        return (
-          <Button size="sm" variant="outline" disabled className="flex items-center gap-1">
-            Pending
-            <Hourglass className="h-4 w-4" />
-          </Button>
-        );
       } else if (myForm.rejection_reason) {
         return (
           <Button
@@ -159,6 +152,13 @@ const createActionColumns = (
           >
             View Details
             <ExternalLink className="h-4 w-4" />
+          </Button>
+        );
+      } else if (lastUnsignedSigningParty?._id !== mySigningParty?._id) {
+        return (
+          <Button size="sm" variant="outline" disabled className="flex items-center gap-1">
+            Pending
+            <Hourglass className="h-4 w-4" />
           </Button>
         );
       } else {
@@ -301,7 +301,7 @@ export default function MyFormsTable({
       columns={columns}
       data={rows}
       enableColumnVisibility
-      initialSorting={[{ id: "timestamp", desc: true }]}
+      initialSorting={[{ id: "timestamp", desc: false }]}
       pageSizes={[20, 50]}
       toolbarActions={
         exportEnabled ? (


### PR DESCRIPTION
Fixed canceled forms showing a "pending" action instead of the button to view the rejection reason. Also fixed canceled forms showing up in the "pending other signatures" section. Lastly, I flipped the table sort order to be from oldest to newest form.