### PR TITLE
fix: mobile form automation default values layout

### DIFF
--- a/app/docs/forms/page.tsx
+++ b/app/docs/forms/page.tsx
@@ -180,7 +180,7 @@ export default function DocsFormsPage() {
     if (!openFormName) return;
 
     openModal(`form-default-values:${openFormName}`, renderModalContent(), {
-      title: `My Default Values`,
+      title: `My default values`,
       panelClassName: "sm:min-w-[95vw] sm:max-w-[95vw] sm:w-[95vw] sm:h-[90vh] sm:flex sm:flex-col",
       contentClassName: "flex-1 overflow-hidden p-4",
       showHeaderDivider: true,

--- a/components/docs/MyFormRow.tsx
+++ b/components/docs/MyFormRow.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React from "react";
-import { Eye } from "lucide-react";
+import { Edit, Eye } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export type FormItem = {
   name: string;
@@ -26,6 +27,8 @@ export default function MyFormRow({
   loading?: boolean;
   index?: number;
 }) {
+  const isMobile = useIsMobile();
+
   return (
     <div
       role="row"
@@ -49,11 +52,17 @@ export default function MyFormRow({
       </div>
       <div role="cell" className="col-span-2"></div>
 
-      {/* Form values (eye) */}
+      {/* Form values */}
       <div role="cell" className="col-span-2 flex items-center justify-center">
-        <Button variant="outline" onClick={onOpenAutoSignForm}>
-          My Default Values <Eye className="mt-0.5 h-3 w-3 text-slate-700" />
-        </Button>
+        {isMobile ? (
+          <Button variant="outline" onClick={onOpenAutoSignForm}>
+            <Edit />
+          </Button>
+        ) : (
+          <Button variant="outline" onClick={onOpenAutoSignForm}>
+            Edit <Edit />
+          </Button>
+        )}
       </div>
 
       {/* Auto-sign toggle */}

--- a/components/docs/form-editor/form-layout/FormDefaultValueCapture.tsx
+++ b/components/docs/form-editor/form-layout/FormDefaultValueCapture.tsx
@@ -128,11 +128,11 @@ const FormDefaultValueCaptureContent = ({
   };
 
   return (
-    <div className="relative flex h-full w-full flex-col gap-5 overflow-hidden">
+    <div className="relative flex h-full w-full flex-col gap-4 overflow-hidden">
       {/* Main content with split layout - Form on left, PDF on right */}
-      <div className="flex flex-1 gap-5 overflow-hidden">
+      <div className="flex flex-1 flex-col-reverse gap-4 overflow-hidden md:flex-row">
         {/* Left side - Form */}
-        <div className="relative flex-1 overflow-y-auto bg-white">
+        <div className="relative h-1/2 flex-1 overflow-y-auto bg-white md:h-full">
           {filteredBlocks.length > 0 ? (
             <FormPreviewRenderer
               formName={formName}
@@ -152,7 +152,7 @@ const FormDefaultValueCaptureContent = ({
         </div>
 
         {/* Right side - PDF Preview */}
-        <div className="relative flex-1 overflow-hidden bg-slate-100">
+        <div className="relative h-1/2 flex-1 overflow-hidden bg-slate-100 md:h-full">
           {documentUrl && hasRenderablePreviewField ? (
             <FormPreviewPdfDisplay
               documentUrl={documentUrl}
@@ -186,7 +186,7 @@ const FormDefaultValueCaptureContent = ({
 
       {/* Save Button */}
       {onSave && (
-        <div className="flex items-center justify-end border-t border-slate-200 bg-white p-4">
+        <div className="flex items-center justify-end border-t border-slate-200 bg-white pt-4">
           <Button onClick={handleSave} disabled={isSaving} size="sm">
             {isSaving && <Loader2 className="h-2.5 w-2.5 animate-spin" />}
             {isSaving ? "Saving..." : "Save Default Values"}

--- a/components/docs/form-editor/form-layout/FormPreviewRenderer.tsx
+++ b/components/docs/form-editor/form-layout/FormPreviewRenderer.tsx
@@ -117,7 +117,8 @@ export const FormPreviewRenderer = ({
     const currentField = fieldMap.get(fieldKey);
     if (!currentField || currentField.source !== "manual") return;
 
-    const nextFieldValue = nextValue === undefined ? displayValues[fieldKey] : String(nextValue ?? "");
+    const nextFieldValue =
+      nextValue === undefined ? displayValues[fieldKey] : String(nextValue ?? "");
     const valuesForParams: Record<string, string> =
       nextValue === undefined
         ? displayValues
@@ -159,10 +160,10 @@ export const FormPreviewRenderer = ({
   return (
     <div className="relative flex h-full flex-col rounded-[0.33em] border border-gray-300">
       <div ref={scrollContainerRef} className="relative flex flex-1 flex-col overflow-auto">
-        <div className="px-7 py-5">
+        <div className="px-6 pt-8">
           <h2 className="text-primary text-2xl font-bold">{formLabel || formName}</h2>
         </div>
-        <div className="mt-7 flex-1 space-y-2 border-r border-gray-300 px-7">
+        <div className="flex-1 space-y-2 px-6">
           <BlocksRenderer
             formKey={formName}
             blocks={sortedBlocks}


### PR DESCRIPTION
Changed the layout on the form default values modal to a columnar one on mobile to make better use of screen real estate. A known bug is that the field highlight does not properly center the field in the preview on mobile. I'll look into this further.